### PR TITLE
feat: add /debug command and refine memory management logic

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,9 +7,10 @@ import os
 import signal
 
 # Local imports
+import config
 from config import VERSION, MODEL_NAME
 from theme import Theme
-from utils import RedirectedStdout, round_rectangle
+from utils import RedirectedStdout, round_rectangle, debug_print
 from ui_components import CustomScrollbar
 from markdown_engine import MarkdownEngine
 from shell_integration import ShellIntegration
@@ -35,6 +36,7 @@ class AssistantApp:
         self.SLASH_COMMANDS = [
             ["/bypass", "Send raw prompt directly to model"],
             ["/clear", "Clear conversation history"],
+            ["/debug", "Toggle debug mode"],
             ["/forget", "Reset long-term memory"],
             ["/help", "Show this help message"],
             ["/info", "Toggle model & system information"],
@@ -287,6 +289,7 @@ class AssistantApp:
         try:
             cmd_map = {
                 '/clear': self._cmd_clear,
+                '/debug': self._cmd_debug,
                 '/forget': self._cmd_forget,
                 '/info': self._cmd_info,
                 '/help': self._cmd_help,
@@ -352,12 +355,18 @@ class AssistantApp:
 
     def _cmd_clear(self, _):
         self.assistant.messages = []
-        print("Conversation memory cleared.")
+        debug_print("[*] Conversation memory cleared.")
         self.msg_queue.put(("clear", None, None))
         self.msg_queue.put(("enable", None, None))
 
     def _cmd_forget(self, _):
         self.assistant.clear_long_term_memory()
+        self.msg_queue.put(("enable", None, None))
+
+    def _cmd_debug(self, _):
+        config.DEBUG = not config.DEBUG
+        status = "ENABLED" if config.DEBUG else "DISABLED"
+        print(f"[*] Debug mode {status}")
         self.msg_queue.put(("enable", None, None))
 
     def _cmd_info(self, _):

--- a/src/config.py
+++ b/src/config.py
@@ -2,4 +2,6 @@ import os
 
 VERSION = "0.0.2"
 MODEL_NAME = os.environ.get("LOKALITY_MODEL", "gemma3:4b-it-qat")
+
+# This can be toggled at runtime via /debug
 DEBUG = os.environ.get("DEBUG", "0") == "1"

--- a/src/local_assistant.py
+++ b/src/local_assistant.py
@@ -4,11 +4,13 @@ import threading
 import os
 import re
 
-from config import MODEL_NAME, VERSION, DEBUG
+import config
+from config import MODEL_NAME, VERSION
 from memory import MemoryStore
 from memory_manager import MemoryManager
 from search_engine import SearchEngine
 from stats_collector import StatsCollector
+from utils import debug_print
 
 client = ollama.Client()
 
@@ -37,7 +39,7 @@ class LocalChatAssistant:
             "4. ASK DON'T GUESS: If the user asks something about themselves that isn't in memory, politely state that you don't know yet and ask them for the information.\n"
             "5. SEARCH FOR TRANSIENT INFO: Use search results for news and weather, but trust memory for identity.\n"
             "6. LOCAL TIME: You have access to the current local time in the header above. Use it to answer questions about the current time or date directly without searching.\n"
-            "7. CONCISENESS MANDATE: Always provide the most brief and direct response possible. Do NOT elaborate unless the User explicitly asks for a long or detailed explanation.\n\n"
+            "7. RESPONSE GUIDELINE: Aim for responses that are around one paragraph in length. You may be shorter for simple queries or longer when the complexity of the request warrants a more detailed explanation.\n\n"
             "Be conversational, precise, and professional."
         )
 
@@ -50,19 +52,17 @@ class LocalChatAssistant:
         ).start()
 
     def _perform_memory_update(self, user_input, assistant_response):
-        if DEBUG:
-            print(f"\033[94m[*] Memory: _perform_memory_update called with input: '{user_input[:50]}...'\033[0m")
+        debug_print(f"[*] Memory: _perform_memory_update called with input: '{user_input[:50]}...'")
             
         # OPTIMIZATION: Skip extraction for trivial/short inputs
         filler_words = {"thanks", "thank", "ok", "okay", "cool", "nice", "hello", "hi", "bye", "yes", "no", "yep", "nope"}
         clean_input = re.sub(r'[^a-zA-Z\s]', '', user_input).lower().strip()
         
         if len(clean_input.split()) < 3 and (not clean_input or clean_input in filler_words):
-            if DEBUG:
-                print("\033[94m[*] Memory: Skipping trivial turn.\033[0m")
+            debug_print("[*] Memory: Skipping trivial turn.")
             return
 
-        print("\033[94m[*] Memory: Starting update check...\033[0m")
+        debug_print("[*] Memory: Starting update check...")
         
         # Get structured facts for deduplication
         all_facts_raw = self.memory.get_relevant_facts(user_input)
@@ -71,10 +71,10 @@ class LocalChatAssistant:
         ops = MemoryManager.extract_facts(user_input, assistant_response, all_facts_text)
         
         if not ops:
-            print("\033[94m[*] Memory: No meaningful changes detected.\033[0m")
+            debug_print("[*] Memory: No meaningful changes detected.")
             return
             
-        print(f"\033[94m[*] Memory: LLM suggested {len(ops)} operations.\033[0m")
+        debug_print(f"[*] Memory: LLM suggested {len(ops)} operations.")
         updated = False
         for op in ops:
             if not isinstance(op, dict): continue
@@ -84,42 +84,50 @@ class LocalChatAssistant:
             # HARD FILTER: Block transient info
             forbidden = {"temperature", "humidity", "weather", "forecast", "currently is", "at the moment", "today is", "tonight", "tomorrow", "yesterday", "language model", "conversation turn"}
             if any(key in fact.lower() for key in forbidden):
-                print(f"\033[93m[*] Memory: BLOCKED Transient/Meta Fact -> {fact[:40]}...\033[0m")
+                debug_print(f"[*] Memory: BLOCKED Transient/Meta Fact -> {fact[:40]}...")
                 continue
 
             # Robustness: Strip hallucinated (ID: #) suffixes
             fact = re.sub(r'\s*\(ID:\s*\d+\)$', '', fact).strip()
-            if action == 'create': action = 'update' if fact_id is not None else 'add'
             
-            print(f"\033[94m[*] Memory: Attempting {action} | {entity}: {fact[:30]}...\033[0m")
+            # Verify existence for update/remove
+            exists = False
+            if fact_id is not None:
+                # We can use memory.is_name_fact or similar, but let's just check if it exists
+                # For simplicity, we'll assume it doesn't exist if it's not in our recently fetched all_facts_raw
+                exists = any(f['id'] == fact_id for f in all_facts_raw)
+
+            debug_print(f"[*] Memory: Attempting {action} | {entity}: {fact[:30]}...")
 
             if action == 'add' and fact:
                 clean_fact = re.sub(r'[^a-zA-Z0-9]', '', fact).lower()
                 is_duplicate = any(entity.lower() == f['entity'].lower() and clean_fact == re.sub(r'[^a-zA-Z0-9]', '', f['fact']).lower() for f in all_facts_raw)
                 
                 if not is_duplicate:
-                    print(f"\033[92m[*] Memory: COMMIT ADD -> {entity}: {fact}\033[0m")
+                    debug_print(f"[*] Memory: COMMIT ADD -> {entity}: {fact}")
                     self.memory.add_fact(entity, fact)
                     updated = True
                 else:
-                    print(f"\033[93m[*] Memory: BLOCKED Duplicate for {entity} -> {fact}\033[0m")
+                    debug_print(f"[*] Memory: BLOCKED Duplicate for {entity} -> {fact}")
             
-            elif action == 'remove' and fact_id is not None:
-                print(f"\033[92m[*] Memory: COMMIT REMOVE -> ID {fact_id}\033[0m")
+            elif action == 'remove' and fact_id is not None and exists:
+                debug_print(f"[*] Memory: COMMIT REMOVE -> ID {fact_id}")
                 self.memory.remove_fact(fact_id)
                 updated = True
-            elif action == 'update' and fact_id is not None and fact:
-                print(f"\033[92m[*] Memory: COMMIT UPDATE -> ID {fact_id}: {fact}\033[0m")
+            elif action == 'update' and fact_id is not None and exists and fact:
+                debug_print(f"[*] Memory: COMMIT UPDATE -> ID {fact_id}: {fact}")
                 self.memory.update_fact(fact_id, entity, fact)
                 updated = True
+            elif action in ['update', 'remove'] and not exists:
+                debug_print(f"[*] Memory: BLOCKED {action} -> ID {fact_id} not found in recent context.")
         
         if updated:
-            print("\033[92m[*] Memory: Database updated, refreshing system prompt.\033[0m")
+            debug_print("[*] Memory: Database updated, refreshing system prompt.")
             self._update_system_prompt(user_input)
         else:
-            print("\033[94m[*] Memory: No changes were committed to database.\033[0m")
+            debug_print("[*] Memory: No changes were committed to database.")
         
-        print("\033[94m[*] Memory: Update check finished.\033[0m")
+        debug_print("[*] Memory: Update check finished.")
 
     def decide_and_search(self, user_input):
         """Uses a single high-speed call to decide if search is needed and generate the query."""
@@ -139,6 +147,7 @@ class LocalChatAssistant:
         try:
             res = client.generate(model=MODEL_NAME, prompt=decision_prompt)
             response = res['response'].strip()
+            debug_print(f"[*] Search Decision: {response}")
             
             if response.upper().startswith("SEARCH:"):
                 query = response[7:].strip().strip('"')
@@ -152,7 +161,7 @@ class LocalChatAssistant:
         """Resets the internal long-term memory."""
         self.memory.clear()
         self._update_system_prompt()
-        print("\033[90mLong-term memory cleared.\033[0m")
+        debug_print("[*] Long-term memory cleared.")
 
     def get_model_info(self):
         return StatsCollector.get_model_info(self.memory, self.system_prompt, self.messages)

--- a/src/memory.py
+++ b/src/memory.py
@@ -2,6 +2,7 @@ import sqlite3
 import os
 import re
 import threading
+from utils import debug_print
 
 class MemoryStore:
     def __init__(self, db_path=None):
@@ -64,7 +65,7 @@ class MemoryStore:
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_created ON memory(created_at)")
                 conn.commit()
         except sqlite3.Error as e:
-            print(f"\033[91m[*] Memory: Database error during init: {e}. Resetting...\033[0m")
+            debug_print(f"[*] Memory: Database error during init: {e}. Resetting...")
             self._reset_corrupted_db()
 
     def _get_conn(self):
@@ -137,7 +138,7 @@ class MemoryStore:
                             for r in cursor.fetchall():
                                 all_facts.append({"id": r['id'], "entity": r['entity'], "fact": r['fact']})
         except sqlite3.Error as e:
-            print(f"\033[91m[*] Memory: Runtime error: {e}\033[0m")
+            debug_print(f"[*] Memory: Runtime error: {e}")
             return []
 
         # Deduplicate while preserving order
@@ -193,9 +194,9 @@ class MemoryStore:
                 path = self.db_path + ext
                 if os.path.exists(path):
                     os.remove(path)
-            print(f"[*] Memory: Database files cleared.")
+            debug_print(f"[*] Memory: Database files cleared.")
         except Exception as e:
-            print(f"[*] Memory: Failed to delete database files: {e}")
+            debug_print(f"[*] Memory: Failed to delete database files: {e}")
             # Fallback: at least try to clear the main table
             try:
                 conn = self._get_conn()

--- a/src/search_engine.py
+++ b/src/search_engine.py
@@ -1,10 +1,11 @@
 from ddgs import DDGS
+from utils import debug_print
 
 class SearchEngine:
     @staticmethod
     def web_search(query):
         """Performs a DuckDuckGo search and returns the top results."""
-        print(f"[\033[90m*] Searching for: {query}[\033[0m")
+        debug_print(f"[*] Searching for: {query}")
         try:
             with DDGS() as ddgs:
                 results = list(ddgs.text(query, max_results=5))

--- a/src/stats_collector.py
+++ b/src/stats_collector.py
@@ -1,5 +1,6 @@
 from config import MODEL_NAME
 import ollama
+from utils import debug_print
 
 client = ollama.Client()
 
@@ -44,6 +45,6 @@ class StatsCollector:
             stats["context_pct"] = min(100, (estimated_tokens / max_ctx) * 100)
             
         except Exception as e:
-            print(f"Error gathering info: {e}")
+            debug_print(f"[*] Error gathering info: {e}")
             
         return stats

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,16 @@
 import re
+import config
 
 # ANSI escape code stripper
 ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\-_]| \[0-?]*[ -/]*[@-~])')
 
 def strip_ansi(text):
     return ANSI_ESCAPE.sub('', text)
+
+def debug_print(msg):
+    """Prints only if DEBUG is enabled in config."""
+    if config.DEBUG:
+        print(msg)
 
 def round_rectangle(canvas, x1, y1, x2, y2, radius=25, **kwargs):
     """Draws a rounded rectangle on a Tkinter Canvas."""


### PR DESCRIPTION
- Implement /debug slash command to toggle runtime debug logging.
- Add debug_print utility and standardize logs with '[*] <msg>' format.
- Remove ANSI escape codes from debug output.
- Update system prompt to aim for one-paragraph response length.
- Strengthen memory management to prefer 'add' operations over 'update'.

Closes #7 