### PR TITLE
feat: implement persistent settings for UI toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.pyc
 res/memory.db*
+res/settings.json
 .gemini/
 .vscode/**
 logs/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -52,6 +52,11 @@ A Python-based GUI chat assistant powered by Ollama and real-time DuckDuckGo sea
 - **Hardware-Safe Scaling**: Dynamically adjusts `num_ctx` based on available VRAM headroom to prevent OOM errors while maximizing context for complex tasks.
 - **Creativity Mapping**: Predicts creative intent to adjust sampling parameters (`temperature`, `top_p`, `top_k`) for more varied or deterministic responses.
 
+### 6. Persistent Settings
+- **State Preservation**: Certain UI and session toggles (e.g., `debug` mode, `info` panel visibility) are persisted between application restarts.
+- **Storage**: Settings are stored in a lightweight JSON format (`res/settings.json`), managed by the `Settings` class in `src/settings.py`.
+- **Initialization**: Persistent states are applied during the asynchronous initialization phase to ensure the UI correctly reflects the user's last session state upon startup.
+
 ## Project Structure
 
 - `src/`: Refactored into specialized modules.
@@ -61,6 +66,7 @@ A Python-based GUI chat assistant powered by Ollama and real-time DuckDuckGo sea
   - `theme.py`: UI styling, colors, and font definitions.
   - `markdown_engine.py`: Dispatcher-based logic for rendering Markdown tokens into Tkinter widgets. Supports complex nesting and modern Mistune plugins.
   - `logger.py`: Centralized logging configuration with automatic file-based persistence and cleanup logic.
+  - `settings.py`: Handles loading and saving of persistent application settings.
   - `shell_integration.py`: PTY-based logic for the direct Ollama bypass.
   - `local_assistant.py`: Core logic for conversation management and system prompt templating.
   - `memory.py`: Low-level SQLite database interface with FTS5 triggers.
@@ -71,6 +77,7 @@ A Python-based GUI chat assistant powered by Ollama and real-time DuckDuckGo sea
   - `utils.py`: Shared utilities (rounded rectangles, ANSI stripping, environment health checks).
 - `res/`: Persistent data.
   - `memory.db`: The SQLite database for long-term memory.
+  - `settings.json`: Persistent application configuration (ignored by git).
 - `launch.sh`: Main entry point for launching the application via `src/app.py`.
 
 ## Development Conventions
@@ -80,4 +87,5 @@ A Python-based GUI chat assistant powered by Ollama and real-time DuckDuckGo sea
 - **Selective Learning**: The assistant is extractive and strict, focusing on permanent user attributes and identity facts.
 - **Code Quality**: Strict adherence to Pylint standards. A perfect **10.00/10** score is required. Disabling Pylint warnings via comments (e.g., `# pylint: disable=...`) is **STRICTLY FORBIDDEN**. Code must be refactored to comply with rules and best practices.
 - **Testing**: All changes must be verified with the test suite: `PYTHONPATH=src .venv/bin/python -m unittest discover tests`.
+- **GitHub Interaction**: Always use `gh` commands when interacting with GitHub (PRs, issues, repository metadata, etc.).
 - **Git & Version Control**: NEVER execute `git commit` or any command that modifies the commit history unless explicitly instructed to do so by the user for a specific set of changes. Preliminary staging (`git add`) is acceptable for preparation, but final commits are user-gated.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ PYTHONPATH=src .venv/bin/python3 -m unittest discover tests
 - **Real-Time Web Search**: Dynamically decides when to search the internet using DuckDuckGo to provide up-to-date information.
 - **Dynamic Complexity Scoring**: Analyzes user prompts to predict required thinking effort and creativity, dynamically adjusting model parameters (context window, temperature, penalties) and ensuring VRAM safety.
 - **Model & System Info**: Use `/info` to toggle a live info bar showing Model, Remaining Context, Long-term Memory size, and RAM/VRAM usage.
+- **Persistent Toggles**: Toggles like `/debug` and `/info` now persist between application sessions, automatically restoring your preferred UI state on launch.
 - **Advanced Markdown Support**: 
     - Full support for **Headings**, **Bold**, **Italics**, **Strikethrough**, **Subscript**, and **Superscript**.
     - Nested styling (e.g., ***Bold Italic***) support.

--- a/src/search_engine.py
+++ b/src/search_engine.py
@@ -5,10 +5,10 @@ Handles web searching via DuckDuckGo and URL scraping.
 import requests
 from bs4 import BeautifulSoup
 try:
-    from duckduckgo_search import DDGS
+    from ddgs import DDGS
 except ImportError:
     try:
-        from ddgs import DDGS
+        from duckduckgo_search import DDGS
     except ImportError:
         # Fallback for environments where neither is found during type checking/linting
         DDGS = None

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,45 @@
+"""
+Persistent settings management for Lokality.
+"""
+import json
+import os
+from logger import logger
+
+SETTINGS_FILE = os.path.join("res", "settings.json")
+
+class Settings:
+    """Handles loading and saving application settings."""
+    def __init__(self):
+        self.settings = {
+            "debug": False,
+            "show_info": False
+        }
+        self.load()
+
+    def load(self):
+        """Loads settings from the JSON file."""
+        if os.path.exists(SETTINGS_FILE):
+            try:
+                with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+                    loaded = json.load(f)
+                    self.settings.update(loaded)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.error("Failed to load settings: %s", exc)
+
+    def save(self):
+        """Saves current settings to the JSON file."""
+        try:
+            os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+            with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.settings, f, indent=4)
+        except OSError as exc:
+            logger.error("Failed to save settings: %s", exc)
+
+    def get(self, key, default=None):
+        """Retrieves a setting value."""
+        return self.settings.get(key, default)
+
+    def set(self, key, value):
+        """Sets a setting value and saves."""
+        self.settings[key] = value
+        self.save()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for settings persistence.
+"""
+import unittest
+import os
+import shutil
+import src.settings
+from src.settings import Settings
+
+class TestSettings(unittest.TestCase):
+    """Test suite for settings management."""
+
+    def setUp(self):
+        """Set up a temporary res directory."""
+        self.res_dir = "res_test"
+        if os.path.exists(self.res_dir):
+            shutil.rmtree(self.res_dir)
+        os.makedirs(self.res_dir)
+
+        # Patch SETTINGS_FILE in settings module
+        self.original_file = src.settings.SETTINGS_FILE
+        src.settings.SETTINGS_FILE = os.path.join(self.res_dir, "settings.json")
+
+    def tearDown(self):
+        """Clean up the temporary res directory."""
+        if os.path.exists(self.res_dir):
+            shutil.rmtree(self.res_dir)
+
+        # Restore SETTINGS_FILE
+        src.settings.SETTINGS_FILE = self.original_file
+
+    def test_default_settings(self):
+        """Test that default settings are correct."""
+        settings = Settings()
+        self.assertFalse(settings.get("debug"))
+        self.assertFalse(settings.get("show_info"))
+
+    def test_save_load_settings(self):
+        """Test saving and then loading settings."""
+        settings = Settings()
+        settings.set("debug", True)
+        settings.set("show_info", True)
+
+        # Create a new settings object to force reload
+        new_settings = Settings()
+        self.assertTrue(new_settings.get("debug"))
+        self.assertTrue(new_settings.get("show_info"))
+
+    def test_invalid_json(self):
+        """Test behavior with invalid JSON in settings file."""
+        with open(src.settings.SETTINGS_FILE, "w", encoding="utf-8") as f:
+            f.write("invalid json")
+
+        settings = Settings()
+        # Should fall back to defaults
+        self.assertFalse(settings.get("debug"))


### PR DESCRIPTION
- Add Settings manager in src/settings.py to handle JSON-based persistence in res/settings.json.
- Update AssistantApp to persist /debug and /info states across sessions.
- Trigger initial info panel update on startup when show_info is enabled.
- Refactor AssistantApp to use class-level SLASH_COMMANDS for Pylint compliance (10.00/10 score).
- Update .gitignore to exclude local settings.json.
- Update GEMINI.md and README.md with new features and dev conventions.
- Add unit tests for settings persistence in tests/test_settings.py.

Closes #43 