### PR TITLE
feat: enhance thinking indicator and refactor AppState for quality

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,3 +27,6 @@ DEBUG = os.environ.get("DEBUG", "0") == "1"
 LOG_DIR = "logs"
 MAX_LOG_AGE_DAYS = 30
 MIN_LOGS_FOR_CLEANUP = 10
+
+# UI Indicator
+INDICATOR_CHARS = ["ʘ", "Ο"]

--- a/src/markdown_engine.py
+++ b/src/markdown_engine.py
@@ -144,7 +144,7 @@ class MarkdownEngine:
     def _handle_paragraph(self, token, base_tag, style_tags, level):
         """Renders a paragraph token."""
         self.render_tokens(token['children'], base_tag, style_tags, level)
-        self.text_widget.insert(tk.END, "\n" if level > 0 else "\n\n")
+        self.text_widget.insert("end-1c", "\n" if level > 0 else "\n\n")
 
     def _handle_block_text(self, token, base_tag, style_tags, level):
         """Renders a block_text token."""
@@ -154,7 +154,7 @@ class MarkdownEngine:
         """Renders a text token."""
         del level
         content = token.get('raw', token.get('text', ''))
-        self.text_widget.insert(tk.END, content, tuple(style_tags + [base_tag]))
+        self.text_widget.insert("end-1c", content, tuple(style_tags + [base_tag]))
 
     def _handle_strong(self, token, base_tag, style_tags, level):
         """Renders a strong token."""
@@ -182,27 +182,27 @@ class MarkdownEngine:
     def _handle_codespan(self, token, base_tag, style_tags, level):
         """Renders a codespan token."""
         del style_tags, level
-        self.text_widget.insert(tk.END, token.get('raw', ''), ("md_code", base_tag))
+        self.text_widget.insert("end-1c", token.get('raw', ''), ("md_code", base_tag))
 
     def _handle_block_code(self, token, base_tag, style_tags, level):
         """Renders a block_code token."""
         del style_tags, level
-        self.text_widget.insert(tk.END, token.get('raw', ''), ("md_code", base_tag))
-        self.text_widget.insert(tk.END, "\n", base_tag)
+        self.text_widget.insert("end-1c", token.get('raw', ''), ("md_code", base_tag))
+        self.text_widget.insert("end-1c", "\n", base_tag)
 
     def _handle_heading(self, token, base_tag, style_tags, level):
         """Renders a heading token."""
         del style_tags
         if self.text_widget.index("end-1c") != "1.0":
-            self.text_widget.insert(tk.END, "\n")
+            self.text_widget.insert("end-1c", "\n")
         h_level = min(3, token['attrs']['level'])
         self.render_tokens(token['children'], base_tag, f"md_h{h_level}", level)
-        self.text_widget.insert(tk.END, "\n")
+        self.text_widget.insert("end-1c", "\n")
 
     def _handle_softbreak(self, token, base_tag, style_tags, level):
         """Renders a softbreak token."""
         del token, base_tag, style_tags, level
-        self.text_widget.insert(tk.END, "\n")
+        self.text_widget.insert("end-1c", "\n")
 
     def _handle_thematic_break(self, token, base_tag, style_tags, level):
         """Renders a thick horizontal rule."""
@@ -214,20 +214,20 @@ class MarkdownEngine:
         )
         canv.create_line(0, 3, width, 3, fill=Theme.ACCENT_COLOR, width=4)
         self._bind_scroll(canv)
-        self.text_widget.insert(tk.END, "\n")
-        self.text_widget.window_create(tk.END, window=canv)
-        self.text_widget.insert(tk.END, "\n\n")
+        self.text_widget.insert("end-1c", "\n")
+        self.text_widget.window_create("end-1c", window=canv)
+        self.text_widget.insert("end-1c", "\n\n")
 
     def _handle_block_quote(self, token, base_tag, style_tags, level):
         """Renders a blockquote with a vertical sidebar indicator."""
         if self.text_widget.index("end-1c") != "1.0":
-            self.text_widget.insert(tk.END, "\n")
-        self.text_widget.insert(tk.END, "┃ ", ("md_quote_bar", base_tag))
+            self.text_widget.insert("end-1c", "\n")
+        self.text_widget.insert("end-1c", "┃ ", ("md_quote_bar", base_tag))
         self.render_tokens(
             token['children'], base_tag, style_tags + ["md_quote"], level + 1
         )
         if self.text_widget.get("end-2c", "end-1c") != "\n":
-            self.text_widget.insert(tk.END, "\n")
+            self.text_widget.insert("end-1c", "\n")
 
     def _handle_list(self, token, base_tag, style_tags, level):
         """Renders a list token."""
@@ -241,12 +241,12 @@ class MarkdownEngine:
                 self.text_widget.get("end-2c", "end-1c") != "\n" and
                 self.text_widget.index("end-1c") != "1.0"
             ):
-                self.text_widget.insert(tk.END, "\n")
+                self.text_widget.insert("end-1c", "\n")
             prefix = f"{indent}{start + i}. " if ordered else f"{indent}• "
-            self.text_widget.insert(tk.END, prefix, base_tag)
+            self.text_widget.insert("end-1c", prefix, base_tag)
             self.render_tokens(item['children'], base_tag, level=level + 1)
         if level == 0:
-            self.text_widget.insert(tk.END, "\n")
+            self.text_widget.insert("end-1c", "\n")
 
     def _handle_link(self, token, base_tag, style_tags, level):
         """Renders a link token."""
@@ -255,7 +255,7 @@ class MarkdownEngine:
         url = token['attrs']['url']
         link_id = f"link_data_{hash(url)}"
         self.url_map[link_id] = url
-        self.text_widget.insert(tk.END, link_text, ("md_link", link_id))
+        self.text_widget.insert("end-1c", link_text, ("md_link", link_id))
 
     def _handle_table(self, token, base_tag, style_tags, level):
         """Parses and renders a Markdown table."""
@@ -274,9 +274,9 @@ class MarkdownEngine:
                 frame.grid_columnconfigure(j, weight=1)
 
             self._bind_scroll(frame)
-            self.text_widget.insert(tk.END, "\n")
-            self.text_widget.window_create(tk.END, window=frame)
-            self.text_widget.insert(tk.END, "\n")
+            self.text_widget.insert("end-1c", "\n")
+            self.text_widget.window_create("end-1c", window=frame)
+            self.text_widget.insert("end-1c", "\n")
 
         except (ValueError, TypeError, KeyError) as exc:
             debug_print(f"Markdown: Error rendering table: {exc}")

--- a/src/theme.py
+++ b/src/theme.py
@@ -22,6 +22,7 @@ class Theme:
 
     # Tags Colors
     USER_COLOR = "#90CAF9"
+    INDICATOR_COLOR = "#818CF8"  # Electric Indigo
     SYSTEM_COLOR = "#B0BEC5"
     ERROR_COLOR = "#EF9A9A"
     CANCELLED_COLOR = "#B05555"
@@ -51,7 +52,8 @@ class Theme:
             "h2": (base_family, 17, "bold"),
             "h3": (base_family, 14, "bold"),
             "unit": (base_family, 9, "bold"),
-            "tooltip": (base_family, 9)
+            "tooltip": (base_family, 9),
+            "indicator": (base_family, 13)
         }
 
     @staticmethod

--- a/tests/test_markdown_engine.py
+++ b/tests/test_markdown_engine.py
@@ -23,7 +23,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'Hello world', ('base',))
+        self.mock_text.insert.assert_called_with("end-1c", 'Hello world', ('base',))
 
     def test_render_bold(self):
         """Test rendering bold text."""
@@ -32,7 +32,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'Bold text', ('md_bold', 'base'))
+        self.mock_text.insert.assert_called_with("end-1c", 'Bold text', ('md_bold', 'base'))
 
     def test_render_italic(self):
         """Test rendering italic text."""
@@ -43,7 +43,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'Italic text', ('md_italic', 'base'))
+        self.mock_text.insert.assert_called_with("end-1c", 'Italic text', ('md_italic', 'base'))
 
     def test_render_bold_italic(self):
         """Test rendering nested bold and italic text."""
@@ -60,7 +60,7 @@ class TestMarkdownEngine(unittest.TestCase):
         )
         # Should use the combined tag
         self.mock_text.insert.assert_called_with(
-            tk.END, 'Bold Italic', ('md_bold_italic', 'base')
+            "end-1c", 'Bold Italic', ('md_bold_italic', 'base')
         )
 
     def test_render_strikethrough(self):
@@ -73,7 +73,7 @@ class TestMarkdownEngine(unittest.TestCase):
             tokens, "base"
         )
         self.mock_text.insert.assert_called_with(
-            tk.END, 'deleted', ('md_strikethrough', 'base')
+            "end-1c", 'deleted', ('md_strikethrough', 'base')
         )
 
     def test_render_subscript(self):
@@ -85,7 +85,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'sub', ('md_sub', 'base'))
+        self.mock_text.insert.assert_called_with("end-1c", 'sub', ('md_sub', 'base'))
 
     def test_render_superscript(self):
         """Test rendering superscript text."""
@@ -96,7 +96,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'sup', ('md_sup', 'base'))
+        self.mock_text.insert.assert_called_with("end-1c", 'sup', ('md_sup', 'base'))
 
     def test_render_paragraph(self):
         """Test rendering a paragraph."""
@@ -107,8 +107,8 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_any_call(tk.END, 'Para', ('base',))
-        self.mock_text.insert.assert_any_call(tk.END, '\n\n')
+        self.mock_text.insert.assert_any_call("end-1c", 'Para', ('base',))
+        self.mock_text.insert.assert_any_call("end-1c", '\n\n')
 
     def test_render_codespan(self):
         """Test rendering inline code."""
@@ -116,7 +116,7 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_called_with(tk.END, 'code', ('md_code', 'base'))
+        self.mock_text.insert.assert_called_with("end-1c", 'code', ('md_code', 'base'))
 
     def test_render_list_simple(self):
         """Test rendering a simple unordered list."""
@@ -130,8 +130,8 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_any_call(tk.END, "• ", "base")
-        self.mock_text.insert.assert_any_call(tk.END, 'Item 1', ('base',))
+        self.mock_text.insert.assert_any_call("end-1c", "• ", "base")
+        self.mock_text.insert.assert_any_call("end-1c", 'Item 1', ('base',))
 
     def test_render_list_ordered(self):
         """Test rendering an ordered list."""
@@ -145,8 +145,8 @@ class TestMarkdownEngine(unittest.TestCase):
         self.engine.render_tokens(
             tokens, "base"
         )
-        self.mock_text.insert.assert_any_call(tk.END, "1. ", "base")
-        self.mock_text.insert.assert_any_call(tk.END, 'First', ('base',))
+        self.mock_text.insert.assert_any_call("end-1c", "1. ", "base")
+        self.mock_text.insert.assert_any_call("end-1c", 'First', ('base',))
 
     def test_render_list_nested(self):
         """Test rendering a nested list."""
@@ -170,10 +170,10 @@ class TestMarkdownEngine(unittest.TestCase):
             tokens, "base"
         )
         # Check parent bullet
-        self.mock_text.insert.assert_any_call(tk.END, "• ", "base")
+        self.mock_text.insert.assert_any_call("end-1c", "• ", "base")
         # Check nested bullet (indented)
-        self.mock_text.insert.assert_any_call(tk.END, "    • ", "base")
-        self.mock_text.insert.assert_any_call(tk.END, 'Child', ('base',))
+        self.mock_text.insert.assert_any_call("end-1c", "    • ", "base")
+        self.mock_text.insert.assert_any_call("end-1c", 'Child', ('base',))
 
     def test_render_blockquote(self):
         """Test rendering a blockquote."""
@@ -185,8 +185,8 @@ class TestMarkdownEngine(unittest.TestCase):
             tokens, "base"
         )
         # Check for bar character and styling
-        self.mock_text.insert.assert_any_call(tk.END, "┃ ", ("md_quote_bar", "base"))
-        self.mock_text.insert.assert_any_call(tk.END, 'Quote', ('md_quote', 'base'))
+        self.mock_text.insert.assert_any_call("end-1c", "┃ ", ("md_quote_bar", "base"))
+        self.mock_text.insert.assert_any_call("end-1c", 'Quote', ('md_quote', 'base'))
 
     def test_render_thematic_break(self):
         """Test rendering a thematic break."""


### PR DESCRIPTION
- Implement a dynamic, persistent thinking indicator in 'src/app.py' and 'src/config.py'.
- Fix vertical alignment: ensure response text starts on the same line as the indicator by using 'end-1c' insertion and mark gravity management.
- Styling: set indicator to Electric Indigo (#818CF8), size 13, non-bold.
- Quality: refactor 'AppState' into nested 'IndicatorState' and 'ResponseState' dataclasses to fix Pylint R0902 (too many instance attributes).
- Standards: fix all trailing whitespace and line length issues in 'src/app.py' (10.00/10 Pylint score).
- Tests: update 'tests/test_markdown_engine.py' and 'src/markdown_engine.py' to use 'end-1c' insertion logic.

Closes #20 
Closes #31 