### PR TITLE
feat: implement model selection sidebar and modularize UI helpers

### DIFF
--- a/src/app_state.py
+++ b/src/app_state.py
@@ -28,13 +28,19 @@ class ProcessState:
     stop_generation: bool = False
 
 @dataclass
+class UIState:
+    """Holds UI visibility state."""
+    show_info: bool = False
+    sidebar_visible: bool = False
+
+@dataclass
 class AppState:
     """Holds the application state."""
     assistant: Optional[Any] = None
     process: ProcessState = field(default_factory=ProcessState)
     auto_scroll: bool = True
     response: ResponseState = field(default_factory=ResponseState)
-    show_info: bool = False
+    ui_state: UIState = field(default_factory=UIState)
     msg_queue: queue.Queue = field(default_factory=queue.Queue)
     indicator: IndicatorState = field(default_factory=IndicatorState)
 
@@ -59,11 +65,20 @@ class InputUI:
     field: Optional[tk.Text] = None
 
 @dataclass
+class SidebarUI:
+    """Holds sidebar UI component references."""
+    frame: Optional[tk.Frame] = None
+    canvas: Optional[tk.Canvas] = None
+    bg_id: Optional[int] = None
+    window_id: Optional[int] = None
+
+@dataclass
 class AppUI:
     """Holds UI component references."""
     chat: ChatUI = field(default_factory=ChatUI)
     input: InputUI = field(default_factory=InputUI)
     info_panel: Optional[InfoPanel] = None
+    sidebar: SidebarUI = field(default_factory=SidebarUI)
     tooltip_window: Optional[tk.Toplevel] = None
 
 @dataclass
@@ -84,5 +99,6 @@ SLASH_COMMANDS = [
     ["/forget", "Reset long-term memory"],
     ["/help", "Show this help message"],
     ["/info", "Toggle model & system information"],
+    ["/model", "Switch the current Ollama model"],
     ["/exit", "Exit the application"]
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -16,9 +16,6 @@ DEFAULT_MODELS = [
 ]
 
 # Model performance tuning
-SEARCH_DECISION_MAX_TOKENS = 100
-MEMORY_EXTRACTION_MAX_TOKENS = 200
-CONTEXT_WINDOW_SIZE = 4096
 
 # This can be toggled at runtime via /debug
 DEBUG = os.environ.get("DEBUG", "0") == "1"

--- a/src/logger.py
+++ b/src/logger.py
@@ -11,7 +11,7 @@ import config
 
 def cleanup_logs(log_dir):
     """
-    Removes logs older than MAX_LOG_AGE_DAYS if there are more than 
+    Removes logs older than MAX_LOG_AGE_DAYS if there are more than
     MIN_LOGS_FOR_CLEANUP files. Also caps total log files at MAX_LOG_FILES.
     """
     log_files = glob.glob(os.path.join(log_dir, "*.txt"))

--- a/src/memory_manager.py
+++ b/src/memory_manager.py
@@ -8,8 +8,6 @@ import re
 import ollama
 
 import config
-from complexity_scorer import ComplexityScorer
-from config import MEMORY_EXTRACTION_MAX_TOKENS, CONTEXT_WINDOW_SIZE
 from utils import debug_print, error_print, get_ollama_client
 
 # client removed from here
@@ -123,9 +121,6 @@ class MemoryManager:
         )
 
         try:
-            # VRAM Safety check for context size
-            safe_ctx = ComplexityScorer.get_safe_context_size(CONTEXT_WINDOW_SIZE)
-
             res = get_ollama_client().chat(
                 model=config.MODEL_NAME,
                 messages=[
@@ -134,8 +129,6 @@ class MemoryManager:
                 ],
                 format="json",
                 options={
-                    "num_predict": MEMORY_EXTRACTION_MAX_TOKENS,
-                    "num_ctx": safe_ctx,
                     "temperature": 0.0
                 }
             )

--- a/src/stats_collector.py
+++ b/src/stats_collector.py
@@ -4,7 +4,7 @@ Monitors model resource usage and estimates context window consumption.
 """
 import ollama
 
-from config import MODEL_NAME
+import config
 from logger import logger
 from utils import debug_print, get_ollama_client
 
@@ -34,7 +34,7 @@ def _get_resource_usage(stats):
         ps = get_ollama_client().ps()
         models_list = getattr(ps, 'models', ps)
         for m in models_list:
-            if m.model.split(":")[0] in MODEL_NAME or MODEL_NAME in m.model:
+            if m.model.split(":")[0] in config.MODEL_NAME or config.MODEL_NAME in m.model:
                 vram_bytes = getattr(m, 'size_vram', 0)
                 total_bytes = getattr(m, 'size', 0)
                 stats["vram_mb"] = vram_bytes // (1024 * 1024)
@@ -48,7 +48,7 @@ def _get_resource_usage(stats):
 def get_model_info(memory_store, system_prompt, messages):
     """Gathers statistics about the model and system."""
     stats = {
-        "model": MODEL_NAME,
+        "model": config.MODEL_NAME,
         "context_pct": 0,
         "memory_entries": memory_store.get_fact_count(),
         "ram_mb": 0,
@@ -59,7 +59,7 @@ def get_model_info(memory_store, system_prompt, messages):
         _get_resource_usage(stats)
 
         # Context estimation
-        show = get_ollama_client().show(MODEL_NAME)
+        show = get_ollama_client().show(config.MODEL_NAME)
         show_dict = show.model_dump()
         max_ctx = 8192 # Default fallback
         model_info = show_dict.get('modelinfo', {})

--- a/src/ui_helpers.py
+++ b/src/ui_helpers.py
@@ -1,0 +1,95 @@
+"""
+GUI helper functions for Lokality.
+"""
+import tkinter as tk
+import theme as Theme
+from app_state import CanvasConfig
+from utils import round_rectangle
+
+def update_canvas_region(cfg: CanvasConfig) -> int:
+    """Unified helper to update rounded rectangles on resize."""
+    w, h = cfg.size
+    outline, line_w, fill = cfg.style
+    px, py = cfg.pad
+    cfg.canvas.delete(cfg.bg_id)
+    nbg = round_rectangle(cfg.canvas, (4, 4, w-4, h-4), radius=cfg.radius,
+                          outline=outline, width=line_w, fill=fill)
+    cfg.canvas.tag_lower(nbg)
+    cfg.canvas.itemconfig(cfg.win_id, width=max(1, w-(px*2)),
+                          height=max(1, h-(py*2)))
+    cfg.canvas.coords(cfg.win_id, px, py)
+    return nbg
+
+def update_lower_border(ui_input, forced_h=None):
+    """Redraws the input area border."""
+    w = ui_input.canvas.winfo_width()
+    h = forced_h if forced_h is not None else ui_input.canvas.winfo_height()
+    if w < 10 or h < 10:
+        return ui_input.bg_id
+
+    inner_h = ui_input.field.winfo_reqheight()
+    cfg = CanvasConfig(
+        canvas=ui_input.canvas,
+        bg_id=ui_input.bg_id,
+        size=(w, h),
+        radius=20,
+        style=(Theme.COMMAND_COLOR, 6, Theme.INPUT_BG),
+        win_id=ui_input.window_id,
+        pad=(8, (h - inner_h) / 2)
+    )
+    return update_canvas_region(cfg)
+
+def highlight_commands(ui_input, commands):
+    """Applies syntax highlighting to valid slash commands."""
+    ui_input.field.tag_remove("command_highlight", "1.0", tk.END)
+    content = ui_input.field.get("1.0", tk.END).strip()
+    if content.startswith("/"):
+        end_idx = content.find(" ")
+        if end_idx == -1:
+            end_idx = content.find("\n")
+
+        cmd = content[:end_idx] if end_idx != -1 else content
+        valid_cmds = [c[0] for c in commands]
+
+        if cmd in valid_cmds:
+            tag_end = f"1.{end_idx}" if end_idx != -1 else "1.end"
+            ui_input.field.tag_add("command_highlight", "1.0", tag_end)
+
+def handle_tab(ui_input, commands):
+    """Handles Tab key for command completion."""
+    content = ui_input.field.get("1.0", tk.INSERT).strip()
+    if content.startswith("/"):
+        matches = [c[0] for c in commands if c[0].startswith(content)]
+        if matches:
+            ui_input.field.delete("1.0", tk.INSERT)
+            ui_input.field.insert("1.0", min(matches, key=len))
+        return "break"
+    return None
+
+def adjust_input_height(ui_input):
+    """Dynamically adjusts the input field height based on content."""
+    try:
+        if ui_input.field.winfo_width() <= 1:
+            new_h = 1
+        else:
+            content = ui_input.field.get("1.0", "end-1c")
+            if not content:
+                new_h = 1
+            else:
+                ui_input.field.update_idletasks()
+                try:
+                    res = ui_input.field.count("1.0", "end", "displaylines")
+                    new_h = res[0] if res else 1
+                except (tk.TclError, AttributeError):
+                    new_h = content.count('\n') + 1
+
+        new_h = min(max(new_h, 1), 8)
+        ui_input.field.config(height=new_h)
+        ui_input.field.update_idletasks()
+
+        total_h = ui_input.field.winfo_reqheight() + 20
+        if abs(int(ui_input.canvas.cget("height")) - total_h) > 2:
+            ui_input.canvas.config(height=total_h)
+            ui_input.bg_id = update_lower_border(ui_input, total_h)
+    except tk.TclError:
+        pass

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -26,10 +26,6 @@ class BaseAssistantTest(unittest.TestCase):
         self.mocks['get_client'] = self.patchers['client'].start()
         self.mocks['client'] = self.mocks['get_client'].return_value
         # Also patch it in other modules just in case
-        self.patchers['client_cs'] = patch(
-            'complexity_scorer.get_ollama_client', new=self.mocks['get_client']
-        )
-        self.patchers['client_cs'].start()
         self.patchers['client_mm'] = patch(
             'memory_manager.get_ollama_client', new=self.mocks['get_client']
         )
@@ -38,11 +34,6 @@ class BaseAssistantTest(unittest.TestCase):
             'stats_collector.get_ollama_client', new=self.mocks['get_client']
         )
         self.patchers['client_sc'].start()
-
-        # ComplexityScorer patch
-        self.patchers['ctx'] = patch('local_assistant.ComplexityScorer.get_safe_context_size')
-        self.mocks['ctx'] = self.patchers['ctx'].start()
-        self.mocks['ctx'].return_value = 2048
 
         # Mock datetime for determinism
         self.patchers['datetime'] = patch('local_assistant.datetime')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -45,6 +45,9 @@ class TestCommands(unittest.TestCase):
         root = mocks[0].return_value
 
         self.app = AssistantApp(root)
+        # Manually trigger assistant initialization with a mock
+        self.app.state.assistant = MagicMock()
+        self.app.state.assistant.messages = []
 
     def tearDown(self):
         """Stop all patchers."""

--- a/tests/test_complexity_scorer.py
+++ b/tests/test_complexity_scorer.py
@@ -2,47 +2,20 @@
 Unit tests for the ComplexityScorer class.
 """
 import unittest
-from unittest.mock import patch
 from complexity_scorer import ComplexityScorer
 
 class TestComplexityScorer(unittest.TestCase):
     """Test suite for ComplexityScorer."""
 
-    def setUp(self):
-        # Mock system resources to ensure consistent test results regardless of host hardware
-        self.resource_patcher = patch('complexity_scorer.get_system_resources')
-        self.mock_resources = self.resource_patcher.start()
-        # Simulate 16GB RAM, 8GB VRAM
-        self.mock_resources.return_value = (16384, 8192)
-
-        # Mock model size to simulate 4GB model
-        self.size_patcher = patch(
-            'complexity_scorer.ComplexityScorer._get_loaded_model_size_mb'
-        )
-        self.mock_size = self.size_patcher.start()
-        self.mock_size.return_value = 4096
-
-        # Mock model max context
-        self.ctx_patcher = patch('complexity_scorer.ComplexityScorer._get_model_max_ctx')
-        self.mock_ctx = self.ctx_patcher.start()
-        self.mock_ctx.return_value = 8192
-
-    def tearDown(self):
-        self.resource_patcher.stop()
-        self.size_patcher.stop()
-        self.ctx_patcher.stop()
-
     def test_minimal_complexity(self):
         """Test very simple inputs trigger MINIMAL level."""
         res = ComplexityScorer.analyze("Hi")
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_MINIMAL)
-        self.assertGreaterEqual(res['params']['num_ctx'], 512)
 
     def test_simple_greeting(self):
         """Test simple inputs like greetings."""
         res = ComplexityScorer.analyze("Hello there")
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_MINIMAL)
-        self.assertGreaterEqual(res['params']['num_ctx'], 512)
 
     def test_moderate_question(self):
         """Test standard questions."""
@@ -52,7 +25,6 @@ class TestComplexityScorer(unittest.TestCase):
         )
         res = ComplexityScorer.analyze(text)
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_MODERATE)
-        self.assertGreaterEqual(res['params']['num_ctx'], 2048)
 
     def test_true_moderate(self):
         """Test a request that should be MODERATE."""
@@ -62,14 +34,12 @@ class TestComplexityScorer(unittest.TestCase):
         )
         res = ComplexityScorer.analyze(text)
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_MODERATE)
-        self.assertGreaterEqual(res['params']['num_ctx'], 2048)
 
     def test_deterministic_complex(self):
         """Test a technical request remains deterministic."""
         text = "Please write a complex Python script to calculate the entropy of a file."
         res = ComplexityScorer.analyze(text)
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_COMPLEX)
-        self.assertGreaterEqual(res['params']['num_ctx'], 2048)
         self.assertLessEqual(res['params']['temperature'], 0.2)
 
     def test_creative_simple(self):
@@ -85,7 +55,6 @@ class TestComplexityScorer(unittest.TestCase):
         text = "Explain quantum physics in detail."
         res = ComplexityScorer.analyze(text)
         self.assertEqual(res['level'], ComplexityScorer.LEVEL_MODERATE)
-        self.assertGreaterEqual(res['params']['num_ctx'], 2048)
         self.assertEqual(res['params']['temperature'], 0.1)
 
 if __name__ == '__main__':

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -8,12 +8,10 @@ from memory_manager import MemoryManager
 class TestMemoryManager(unittest.TestCase):
     """Test suite for MemoryManager."""
 
-    @patch('memory_manager.ComplexityScorer.get_safe_context_size')
     @patch('memory_manager.get_ollama_client')
-    def test_extract_facts_add(self, mock_get_client, mock_ctx):
+    def test_extract_facts_add(self, mock_get_client):
         """Test extracting a single fact addition."""
         mock_client = mock_get_client.return_value
-        mock_ctx.return_value = 2048
         # Mock LLM response for fact extraction
         mock_client.chat.return_value = {
             'message': {
@@ -29,12 +27,10 @@ class TestMemoryManager(unittest.TestCase):
         self.assertEqual(ops[0]['op'], 'add')
         self.assertEqual(ops[0]['fact'], 'Lives in Paris')
 
-    @patch('memory_manager.ComplexityScorer.get_safe_context_size')
     @patch('memory_manager.get_ollama_client')
-    def test_extract_facts_no_change(self, mock_get_client, mock_ctx):
+    def test_extract_facts_no_change(self, mock_get_client):
         """Test when no facts are extracted."""
         mock_client = mock_get_client.return_value
-        mock_ctx.return_value = 2048
         mock_client.chat.return_value = {
             'message': {
                 'content': '{"operations": []}'
@@ -44,12 +40,10 @@ class TestMemoryManager(unittest.TestCase):
         ops = MemoryManager.extract_facts("Hello", "Hi there!", "")
         self.assertEqual(len(ops), 0)
 
-    @patch('memory_manager.ComplexityScorer.get_safe_context_size')
     @patch('memory_manager.get_ollama_client')
-    def test_extract_facts_multiple(self, mock_get_client, mock_ctx):
+    def test_extract_facts_multiple(self, mock_get_client):
         """Test extracting multiple facts."""
         mock_client = mock_get_client.return_value
-        mock_ctx.return_value = 2048
         # Mock LLM response for multiple operations
         mock_client.chat.return_value = {
             'message': {

--- a/tests/test_model_pull.py
+++ b/tests/test_model_pull.py
@@ -2,7 +2,7 @@
 Unit tests for model pulling logic and system resource detection.
 """
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 import local_assistant
 import utils
 from tests.base_test import BaseAssistantTest
@@ -18,13 +18,17 @@ class TestModelPull(BaseAssistantTest):
 
     def test_init_with_existing_models(self):
         """Test initialization when models already exist."""
-        self.mocks['client'].list.return_value = {'models': ['some-model']}
+        mock_response = MagicMock()
+        mock_response.models = [MagicMock(model='some-model')]
+        self.mocks['client'].list.return_value = mock_response
         local_assistant.LocalChatAssistant()
         self.mocks['client'].pull.assert_not_called()
 
     def test_init_no_models_pulls_best_fit(self):
         """Test that the best fitting model is pulled if none exist."""
-        self.mocks['client'].list.return_value = {'models': []}
+        mock_response = MagicMock()
+        mock_response.models = []
+        self.mocks['client'].list.return_value = mock_response
         self.mocks['resources'].return_value = (16384, 8192) # 16GB RAM, 8GB VRAM
         self.mocks['client'].pull.return_value = [{'status': 'success'}]
 
@@ -34,14 +38,18 @@ class TestModelPull(BaseAssistantTest):
 
     def test_init_insufficient_vram_pulls_nothing(self):
         """Test that nothing is pulled if VRAM is insufficient."""
-        self.mocks['client'].list.return_value = {'models': []}
+        mock_response = MagicMock()
+        mock_response.models = []
+        self.mocks['client'].list.return_value = mock_response
         self.mocks['resources'].return_value = (16384, 512)
         local_assistant.LocalChatAssistant()
         self.mocks['client'].pull.assert_not_called()
 
     def test_init_mixed_resources_picks_correct_size(self):
         """Test model selection with mixed resources."""
-        self.mocks['client'].list.return_value = {'models': []}
+        mock_response = MagicMock()
+        mock_response.models = []
+        self.mocks['client'].list.return_value = mock_response
         self.mocks['resources'].return_value = (65536, 1536)
         self.mocks['client'].pull.return_value = [{'status': 'success'}]
 

--- a/tests/test_model_swap.py
+++ b/tests/test_model_swap.py
@@ -1,0 +1,49 @@
+"""
+Unit tests for model swapping functionality.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+from dataclasses import dataclass
+import config
+from local_assistant import LocalChatAssistant
+
+@dataclass
+class MockModel:
+    """Mock model object."""
+    model: str
+
+class TestModelSwap(unittest.TestCase):
+    """Test suite for model swapping."""
+
+    @patch('local_assistant.get_ollama_client')
+    def test_get_available_models(self, mock_get_client):
+        """Test retrieving available models."""
+        mock_client = mock_get_client.return_value
+
+        mock_response = MagicMock()
+        mock_response.models = [
+            MockModel(model='model1:latest'),
+            MockModel(model='model2:latest')
+        ]
+        mock_client.list.return_value = mock_response
+
+        assistant = LocalChatAssistant()
+        models = assistant.get_available_models()
+
+        self.assertIn('model1:latest', models)
+        self.assertIn('model2:latest', models)
+
+    @patch('local_assistant.get_ollama_client')
+    def test_switch_model(self, _mock_get_client):
+        """Test switching the model."""
+        assistant = LocalChatAssistant()
+        assistant.messages = [{"role": "user", "content": "hello"}]
+
+        new_model = "new-model:latest"
+        assistant.switch_model(new_model)
+
+        self.assertEqual(config.MODEL_NAME, new_model)
+        self.assertEqual(assistant.messages, [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,11 +40,13 @@ class TestSettings(unittest.TestCase):
         settings = Settings()
         settings.set("debug", True)
         settings.set("show_info", True)
+        settings.set("model_name", "test-model")
 
         # Create a new settings object to force reload
         new_settings = Settings()
         self.assertTrue(new_settings.get("debug"))
         self.assertTrue(new_settings.get("show_info"))
+        self.assertEqual(new_settings.get("model_name"), "test-model")
 
     def test_invalid_json(self):
         """Test behavior with invalid JSON in settings file."""

--- a/tests/test_stats_collector.py
+++ b/tests/test_stats_collector.py
@@ -37,12 +37,12 @@ class TestStatsCollector(unittest.TestCase):
         mock_client.show.return_value = mock_show
 
         # Change config.MODEL_NAME for test
-        with patch('stats_collector.MODEL_NAME', 'llama3'):
+        with patch('config.MODEL_NAME', 'llama3:latest'):
             stats = get_model_info(
                 mock_memory, "System prompt", [{"content": "User message"}]
             )
 
-            self.assertEqual(stats['model'], 'llama3')
+            self.assertEqual(stats['model'], 'llama3:latest')
             self.assertEqual(stats['memory_entries'], 10)
             self.assertEqual(stats['vram_mb'], 4000)
             self.assertEqual(stats['ram_mb'], 1000)


### PR DESCRIPTION
- Added '/model' slash command to toggle a model selection sidebar for switching Ollama models.
- Implemented model switching logic in 'LocalChatAssistant' with memory reset.
- Refactored UI utility functions from 'AssistantApp' into 'src/ui_helpers.py' for better modularity.
- Removed dynamic context window and token limit handling in 'ComplexityScorer' and 'LocalChatAssistant' in favor of default Ollama handling.
- Updated 'AppState' with 'UIState' to manage sidebar and info panel visibility.
- Added 'tests/test_model_swap.py' and updated existing tests to reflect architecture changes.
- Persist selected model name across sessions in 'res/settings.json'.

Closes #23 